### PR TITLE
Added in Shortcut Autocompleter

### DIFF
--- a/Readline/Autocompleter/Shortcut.php
+++ b/Readline/Autocompleter/Shortcut.php
@@ -52,7 +52,7 @@ namespace Hoa\Console\Readline\Autocompleter {
  *
  * The simplest auto-completer.
  *
- * @author     Ivan Enderlin <ivan.enderlin@hoa-project.net>
+ * @author     Kevin Gravier <kevin@mrkmg.com>
  * @copyright  Copyright © 2007-2012 Ivan Enderlin.
  * @license    New BSD License
  */


### PR DESCRIPTION
Still does not work, need your input. The current implentation of _bindTab does not handle this properly.

Currently _bindTab does not re-write anything typed by the user, only adds to it. It should be able to re-write the current word, so that this class works correctly.
