### PR TITLE
fix tput notice for certain setups (unknown cause)

### DIFF
--- a/Window.php
+++ b/Window.php
@@ -153,7 +153,14 @@ class Window implements \Hoa\Core\Event\Source {
             );
         }
 
-        $tput = Processus::execute('tput cols && tput lines', false);
+        // Fix "tput: No value for $TERM and no -T specified"
+        if(isset($_SERVER['TERM']))
+            $prefix = "TERM={$_SERVER['TERM']}";
+        else
+            $prefix = '';
+
+        $cmd  = "$prefix tput cols && $prefix tput lines";
+        $tput = Processus::execute($cmd, false);
 
         if(!empty($tput)) {
 


### PR DESCRIPTION
I've got a fairly fresh macbook so the setup isn't worn in, but was using it to test code.

I encountered the dreaded "tput: No value for $TERM and no -T specified", despite $TERM and $_SERVER['TERM'] both existing.

After a long time searching, I found this to work best.
