### PR TITLE
Remove error on cygwin emulator

### DIFF
--- a/Tput.php
+++ b/Tput.php
@@ -773,7 +773,7 @@ class Tput {
     public static function getTerm ( ) {
 
         return isset($_SERVER['TERM']) ?
-                   $_SERVER['TERM'] :
+                   (($_SERVER['TERM'] === 'cygwin') ? 'windows-ansi' : $_SERVER['TERM']) :
                    (OS_WIN ? 'windows-ansi' : 'xterm');
     }
 


### PR DESCRIPTION
Its related to issue #36 and the error 
```
Uncaught exception (Hoa\Console\Exception):
Hoa\Console\Tput::parse(): (0) Terminfo file (null) does not exist.
in C:\www\Console\Tput.php at line 615.
```
On cygwin emulator, we use default term as "windows-ansi"