### PR TITLE
Fix a bug in the ambiguity resolver

### DIFF
--- a/GetOption.php
+++ b/GetOption.php
@@ -321,7 +321,7 @@ class GetOption {
 
         $choices = $solution['solutions'];
 
-        if(1 < count($choices))
+        if(1 > count($choices))
             throw new Exception(
                 'Cannot resolve ambiguity, fix your typo in the option %s :-).',
                 2, $solution['option']);


### PR DESCRIPTION
When there is no choice to deal with, we didn't throw the exception.