### PR TITLE
Print character only if printable

### DIFF
--- a/Readline/Readline.php
+++ b/Readline/Readline.php
@@ -251,6 +251,8 @@ class Readline
         if (isset($this->_mapping[$char])) {
             $this->_buffer = $this->_mapping[$char];
         } elseif (false === Ustring::isCharPrintable($char)) {
+            Console\Cursor::bip();
+
             return static::STATE_CONTINUE | static::STATE_NO_ECHO;
         }
 

--- a/Readline/Readline.php
+++ b/Readline/Readline.php
@@ -243,31 +243,31 @@ class Readline
         if (isset($this->_mapping[$char]) &&
             is_callable($this->_mapping[$char])) {
             $mapping = $this->_mapping[$char];
-            $return  = $mapping($this);
-        } else {
-            if (isset($this->_mapping[$char])) {
-                $this->_buffer = $this->_mapping[$char];
-            }
 
-            if ($this->getLineLength() == $this->getLineCurrent()) {
-                $this->appendLine($this->_buffer);
-                $return = static::STATE_CONTINUE;
-            } else {
-                $this->insertLine($this->_buffer);
-                $tail          = mb_substr(
-                    $this->getLine(),
-                    $this->getLineCurrent() - 1
-                );
-                $this->_buffer = "\033[K" . $tail . str_repeat(
-                    "\033[D",
-                    mb_strlen($tail) - 1
-                );
-
-                $return = static::STATE_CONTINUE;
-            }
+            return $mapping($this);
         }
 
-        return $return;
+        if (isset($this->_mapping[$char])) {
+            $this->_buffer = $this->_mapping[$char];
+        }
+
+        if ($this->getLineLength() == $this->getLineCurrent()) {
+            $this->appendLine($this->_buffer);
+
+            return static::STATE_CONTINUE;
+        }
+
+        $this->insertLine($this->_buffer);
+        $tail = mb_substr(
+            $this->getLine(),
+            $this->getLineCurrent() - 1
+        );
+        $this->_buffer = "\033[K" . $tail . str_repeat(
+            "\033[D",
+            mb_strlen($tail) - 1
+        );
+
+        return static::STATE_CONTINUE;
     }
 
     /**

--- a/Readline/Readline.php
+++ b/Readline/Readline.php
@@ -38,6 +38,7 @@ namespace Hoa\Console\Readline;
 
 use Hoa\Console;
 use Hoa\Core;
+use Hoa\Ustring;
 
 /**
  * Class \Hoa\Console\Readline.
@@ -249,6 +250,8 @@ class Readline
 
         if (isset($this->_mapping[$char])) {
             $this->_buffer = $this->_mapping[$char];
+        } elseif (false === Ustring::isCharPrintable($char)) {
+            return static::STATE_CONTINUE | static::STATE_NO_ECHO;
         }
 
         if ($this->getLineLength() == $this->getLineCurrent()) {


### PR DESCRIPTION
Fix #16 and #17.

When a character is not printable, the readline did still print it. In some cases, it could create weird bug (see [1] or [2]). Since we have the `Hoa\Ustring::isCharPrintable`, we can check whether a character is printable or not. Consequently, here is the new logic:

  * We read a character,
  * The buffer receives this character,
  * If there is no mapping for this character and if it is not printable, then we do not print it. We do nothing with it.

So, if we would like to support a control character that is not printable, we must associate a mapping to this character (like we do for `Ctrl-A` for instance).

[1]: https://github.com/hoaproject/Console/issues/16
[2]: https://github.com/hoaproject/Console/issues/17