### PR TITLE
Introduce the `Input` class

### DIFF
--- a/Console.php
+++ b/Console.php
@@ -145,9 +145,10 @@ class Console
     /**
      * Prepare the environment for advanced interactions.
      *
+     * @param   bool  $force    Force it if STDIN is not direct.
      * @return  bool
      */
-    public static function advancedInteraction()
+    public static function advancedInteraction($force = false)
     {
         if (null !== self::$_advanced) {
             return self::$_advanced;
@@ -157,7 +158,7 @@ class Console
             return self::$_advanced = false;
         }
 
-        if (false === self::isDirect(STDIN)) {
+        if (false === $force && false === self::isDirect(STDIN)) {
             return self::$_advanced = false;
         }
 

--- a/Console.php
+++ b/Console.php
@@ -162,8 +162,8 @@ class Console
             return self::$_advanced = false;
         }
 
-        self::$_old = Processus::execute('stty -g');
-        Processus::execute('stty -echo -icanon min 1 time 0');
+        self::$_old = Processus::execute('stty -f /dev/tty -g');
+        Processus::execute('stty -f /dev/tty -echo -icanon min 1 time 0');
 
         return self::$_advanced = true;
     }
@@ -179,7 +179,7 @@ class Console
             return;
         }
 
-        Processus::execute('stty ' . self::$_old);
+        Processus::execute('stty -f /dev/tty ' . self::$_old);
 
         return;
     }

--- a/Console.php
+++ b/Console.php
@@ -127,6 +127,13 @@ class Console
     protected static $_mode   = [];
 
     /**
+     * Input.
+     *
+     * @var \Hoa\Console\Input
+     */
+    protected static $_input  = null;
+
+    /**
      * Output.
      *
      * @var \Hoa\Console\Output
@@ -305,6 +312,34 @@ class Console
             self::IS_LINK      === $mode ||
             self::IS_SOCKET    === $mode ||
             self::IS_BLOCK     === $mode;
+    }
+
+    /**
+     * Set input layer.
+     *
+     * @param   \Hoa\Console\Input  $input    Input.
+     * @return  \Hoa\Console\Input
+     */
+    public static function setInput(Input $input)
+    {
+        $old            = static::$_input;
+        static::$_input = $input;
+
+        return $old;
+    }
+
+    /**
+     * Get input layer.
+     *
+     * @return  \Hoa\Console\Input
+     */
+    public static function getInput()
+    {
+        if (null === static::$_input) {
+            static::$_input = new Input();
+        }
+
+        return static::$_input;
     }
 
     /**

--- a/Console.php
+++ b/Console.php
@@ -169,8 +169,8 @@ class Console
             return self::$_advanced = false;
         }
 
-        self::$_old = Processus::execute('stty -f /dev/tty -g');
-        Processus::execute('stty -f /dev/tty -echo -icanon min 1 time 0');
+        self::$_old = Processus::execute('stty -g < /dev/tty', false);
+        Processus::execute('stty -echo -icanon min 1 time 0 < /dev/tty', false);
 
         return self::$_advanced = true;
     }
@@ -186,7 +186,7 @@ class Console
             return;
         }
 
-        Processus::execute('stty -f /dev/tty ' . self::$_old);
+        Processus::execute('stty ' . self::$_old . ' < /dev/tty', false);
 
         return;
     }

--- a/Cursor.php
+++ b/Cursor.php
@@ -211,15 +211,17 @@ class Cursor
 
         Console::getOutput()->writeAll($user7);
 
+        $input = Console::getInput();
+
         // Read $tput->get('user6').
-        fread(STDIN, 2); // skip \033 and [.
+        $input->read(2); // skip \033 and [.
 
         $x      = null;
         $y      = null;
         $handle = &$y;
 
         do {
-            $char = fread(STDIN, 1);
+            $char = $input->readCharacter();
 
             switch ($char) {
                 case ';':

--- a/Input.php
+++ b/Input.php
@@ -83,6 +83,16 @@ class Input implements Stream\IStream\In
     }
 
     /**
+     * Get underlying stream.
+     *
+     * @return \Hoa\Stream\IStream\In
+     */
+    public function getStream()
+    {
+        return $this->_input;
+    }
+
+    /**
      * Test for end-of-file.
      *
      * @return  bool

--- a/Input.php
+++ b/Input.php
@@ -107,7 +107,6 @@ class Input implements Stream\IStream\In
      *
      * @param   int     $length    Length.
      * @return  string
-     * @throws  \Hoa\Exception
      */
     public function read($length)
     {

--- a/Input.php
+++ b/Input.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Console;
+
+use Hoa\File;
+use Hoa\Stream;
+
+/**
+ * Interface \Hoa\Console\Input.
+ *
+ * This interface represents the input of a program. Most of the time, this is
+ * going to be `php://stdin` but it can be `/dev/tty` if the former has been
+ * closed.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class Input implements Stream\IStream\In
+{
+    /**
+     * Real input stream.
+     *
+     * @var \Hoa\Stream\IStream\In
+     */
+    protected $_input = null;
+
+
+
+    /**
+     * Wraps an `Hoa\Stream\IStream\In` stream.
+     *
+     * @param   \Hoa\Stream\IStream\In  $input    Input.
+     * @return  void
+     */
+    public function __construct(Stream\IStream\In $input = null)
+    {
+        if (null === $input) {
+            if (defined('STDIN') &&
+                false !== @stream_get_meta_data(STDIN)) {
+                $input = new File\Read('php://stdin');
+            } else {
+                $input = new File\Read('/dev/tty');
+            }
+        }
+
+        $this->_input = $input;
+
+        return;
+    }
+
+    /**
+     * Test for end-of-file.
+     *
+     * @return  bool
+     */
+    public function eof()
+    {
+        return $this->_input->eof();
+    }
+
+    /**
+     * Read n characters.
+     *
+     * @param   int     $length    Length.
+     * @return  string
+     * @throws  \Hoa\Exception
+     */
+    public function read($length)
+    {
+        return $this->_input->read($length);
+    }
+
+    /**
+     * Alias of $this->read().
+     *
+     * @param   int     $length    Length.
+     * @return  string
+     */
+    public function readString($length)
+    {
+        return $this->_input->readString($length);
+    }
+
+    /**
+     * Read a character.
+     *
+     * @return  string
+     */
+    public function readCharacter()
+    {
+        return $this->_input->readCharacter();
+    }
+
+    /**
+     * Read a boolean.
+     *
+     * @return  bool
+     */
+    public function readBoolean()
+    {
+        return $this->_input->readBoolean();
+    }
+
+    /**
+     * Read an integer.
+     *
+     * @param   int    $length    Length.
+     * @return  int
+     */
+    public function readInteger($length = 1)
+    {
+        return $this->_input->readInteger($length);
+    }
+
+    /**
+     * Read a float.
+     *
+     * @param   int     $length    Length.
+     * @return  float
+     */
+    public function readFloat($length = 1)
+    {
+        return $this->_input->readFloat($length);
+    }
+
+    /**
+     * Read an array.
+     * Alias of the $this->scanf() method.
+     *
+     * @param   mixed   $argument    Argument (because the behavior is very
+     *                               different according to the implementation).
+     * @return  array
+     */
+    public function readArray($argument = null)
+    {
+        return $this->_input->readArray($argument);
+    }
+
+    /**
+     * Read a line.
+     *
+     * @return  string
+     */
+    public function readLine()
+    {
+        return $this->_input->readLine();
+    }
+
+    /**
+     * Read all, i.e. read as much as possible.
+     *
+     * @param   int  $offset    Offset.
+     * @return  string
+     */
+    public function readAll($offset = 0)
+    {
+        return $this->_input->readAll($offset);
+    }
+
+    /**
+     * Parse input from a stream according to a format.
+     *
+     * @param   string  $format    Format (see printf's formats).
+     * @return  array
+     */
+    public function scanf($format)
+    {
+        return $this->_input->scanf($format);
+    }
+}

--- a/Mouse.php
+++ b/Mouse.php
@@ -130,30 +130,31 @@ class Mouse implements Core\Event\Listenable
             'meta'   => false,
             'ctrl'   => false
         ];
-        $read = [STDIN];
+        $input = Console::getInput();
+        $read  = [$input->getStream()];
 
         while (true) {
             @stream_select($read, $write, $except, 30);
 
-            $string = fread(STDIN, 1);
+            $string = $input->readCharacter();
 
             if ("\033" !== $string) {
                 continue;
             }
 
-            $char = fread(STDIN, 1);
+            $char = $input->readCharacter();
 
             if ('[' !== $char) {
                 continue;
             }
 
-            $char = fread(STDIN, 1);
+            $char = $input->readCharacter();
 
             if ('M' !== $char) {
                 continue;
             }
 
-            $data = fread(STDIN, 3);
+            $data = $input->read(3);
             $cb   = ord($data[0]);
             $cx   = ord($data[1]) - 32;
             $cy   = ord($data[2]) - 32;
@@ -201,7 +202,6 @@ class Mouse implements Core\Event\Listenable
                     } elseif (2 === $cb) {
                         $bucket['button'] = 'right';
                     } else {
-
                         // hover
                         continue 2;
                     }

--- a/Mouse.php
+++ b/Mouse.php
@@ -131,7 +131,7 @@ class Mouse implements Core\Event\Listenable
             'ctrl'   => false
         ];
         $input = Console::getInput();
-        $read  = [$input->getStream()];
+        $read  = [$input->getStream()->getStream()];
 
         while (true) {
             @stream_select($read, $write, $except, 30);

--- a/Test/Unit/Input.php
+++ b/Test/Unit/Input.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Console\Test\Unit;
+
+use Hoa\Console\Input as SUT;
+use Hoa\File;
+use Hoa\Test;
+
+/**
+ * Class \Hoa\Console\Test\Unit\Input.
+ *
+ * Test suite of the input object.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class Input extends Test\Unit\Suite
+{
+    public function case_is_a_stream()
+    {
+        $this
+            ->when($result = new SUT())
+            ->then
+                ->object($result)
+                    ->isInstanceOf('Hoa\Stream\IStream\In');
+    }
+
+    public function case_eof()
+    {
+        $this
+            ->given(
+                $file  = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->eof())
+            ->then
+                ->boolean($result)
+                    ->isEqualTo($file->eof());
+    }
+
+    public function case_read()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('foobar'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->read(3))
+            ->then
+                ->string($result)
+                    ->isEqualTo('foo');
+    }
+
+    public function case_read_string()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('foobar'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->readString(3))
+            ->then
+                ->string($result)
+                    ->isEqualTo('foo');
+    }
+
+    public function case_read_character()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('foobar'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->readCharacter(1))
+            ->then
+                ->string($result)
+                    ->isEqualTo('f');
+    }
+
+    public function case_read_boolean_true()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('1'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->readBoolean())
+            ->then
+                ->boolean($result)
+                    ->isTrue();
+    }
+
+    public function case_read_boolean_false()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('0'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->readBoolean())
+            ->then
+                ->boolean($result)
+                    ->isFalse();
+    }
+
+    public function case_read_integer()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('42'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->readInteger(2))
+            ->then
+                ->integer($result)
+                    ->isEqualTo(42);
+    }
+
+    public function case_read_float()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('4.2'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->readFloat(3))
+            ->then
+                ->float($result)
+                    ->isEqualTo(4.2);
+    }
+
+    public function case_read_array()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('foo bar'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->readArray('%s %s'))
+            ->then
+                ->array($result)
+                    ->isEqualTo([
+                        0 => 'foo',
+                        1 => 'bar'
+                    ]);
+    }
+
+    public function case_read_line()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('foo' . "\n" . 'bar'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->readLine())
+            ->then
+                ->string($result)
+                    ->isEqualTo('foo' . "\n");
+    }
+
+    public function case_read_all()
+    {
+        $this
+            ->given(
+                $content = '4.2foo' . "\n" . 'bar',
+                $file    = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll($content),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->readAll())
+            ->then
+                ->string($result)
+                    ->isEqualTo($content);
+    }
+
+    public function case_scanf()
+    {
+        $this
+            ->given(
+                $file = new File\ReadWrite('hoa://Test/Vfs/Input'),
+                $file->writeAll('foo 42' . "\n" . 'bar 153'),
+                $file->rewind(),
+                $input = new SUT($file)
+            )
+            ->when($result = $input->scanf('%s %d'))
+            ->then
+                ->array($result)
+                    ->isEqualTo([
+                        0 => 'foo',
+                        1 => 42
+                    ])
+
+            ->when($result = $input->scanf('%s %d'))
+            ->then
+                ->array($result)
+                    ->isEqualTo([
+                        0 => 'bar',
+                        1 => 153
+                    ]);
+    }
+}

--- a/Window.php
+++ b/Window.php
@@ -432,7 +432,7 @@ class Window implements Core\Event\Source
         Console::getOutput()->writeAll("\033[21t");
 
         $input  = Console::getInput();
-        $read   = [$input->getStream()];
+        $read   = [$input->getStream()->getStream()];
         $write  = [];
         $except = [];
         $out    = null;
@@ -478,7 +478,7 @@ class Window implements Core\Event\Source
         Console::getOutput()->writeAll("\033[20t");
 
         $input  = Console::getInput();
-        $read   = [$input->getStream()];
+        $read   = [$input->getStream()->getStream()];
         $write  = [];
         $except = [];
         $out    = null;

--- a/Window.php
+++ b/Window.php
@@ -155,15 +155,17 @@ class Window implements Core\Event\Source
         // DECSLPP.
         Console::getOutput()->writeAll("\033[18t");
 
+        $input = Console::getInput();
+
         // Read \033[8;y;xt.
-        fread(STDIN, 4); // skip \033, [, 8 and ;.
+        $input->read(4); // skip \033, [, 8 and ;.
 
         $x      = null;
         $y      = null;
         $handle = &$y;
 
         do {
-            $char = fread(STDIN, 1);
+            $char = $input->readCharacter();
 
             switch ($char) {
                 case ';':
@@ -229,15 +231,17 @@ class Window implements Core\Event\Source
         // DECSLPP.
         Console::getOutput()->writeAll("\033[13t");
 
+        $input = Console::getInput();
+
         // Read \033[3;x;yt.
-        fread(STDIN, 4); // skip \033, [, 3 and ;.
+        $input->read(4); // skip \033, [, 3 and ;.
 
         $x      = null;
         $y      = null;
         $handle = &$x;
 
         do {
-            $char = fread(STDIN, 1);
+            $char = $input->readCharacter();
 
             switch ($char) {
                 case ';':
@@ -427,7 +431,8 @@ class Window implements Core\Event\Source
         // DECSLPP.
         Console::getOutput()->writeAll("\033[21t");
 
-        $read   = [STDIN];
+        $input  = Console::getInput();
+        $read   = [$input->getStream()];
         $write  = [];
         $except = [];
         $out    = null;
@@ -437,13 +442,13 @@ class Window implements Core\Event\Source
         }
 
         // Read \033]l<title>\033\
-        fread(STDIN, 3); // skip \033, ] and l.
+        $input->read(3); // skip \033, ] and l.
 
         do {
-            $char = fread(STDIN, 1);
+            $char = $input->readCharacter();
 
             if ("\033" === $char) {
-                $chaar = fread(STDIN, 1);
+                $chaar = $input->readCharacter();
 
                 if ('\\' === $chaar) {
                     break;
@@ -472,7 +477,8 @@ class Window implements Core\Event\Source
         // DECSLPP.
         Console::getOutput()->writeAll("\033[20t");
 
-        $read   = [STDIN];
+        $input  = Console::getInput();
+        $read   = [$input->getStream()];
         $write  = [];
         $except = [];
         $out    = null;
@@ -482,13 +488,13 @@ class Window implements Core\Event\Source
         }
 
         // Read \033]L<label>\033\
-        fread(STDIN, 3); // skip \033, ] and L.
+        $input->read(3); // skip \033, ] and L.
 
         do {
-            $char = fread(STDIN, 1);
+            $char = $input->readCharacter();
 
             if ("\033" === $char) {
-                $chaar = fread(STDIN, 1);
+                $chaar = $input->readCharacter();
 
                 if ('\\' === $chaar) {
                     break;

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require": {
         "hoa/core"   : "~2.0",
+        "hoa/file"   : "~0.0",
         "hoa/stream" : "~0.0",
         "hoa/ustring": "~3.0"
     },


### PR DESCRIPTION
## Old title

Imagine this case:
```sh
$ php foo.php
```
where `foo.php` is a program that reads from `STDIN`. It works perfectly with `Hoa\Console`.

Now, imagine this other case:
```sh
$ echo "foo\nbar" | php foo.php
```
`STDIN` will contain `foo` and `bar` but the `Hoa\Console\Cursor` —for instance— will no longer work since it reads from `STDIN` too.

The idea is then to close `STDIN` (aka `php://input`) and open `/dev/tty`, which is the real standard input in this case.

So, to address these needs, we introduce the `Hoa\Console::getStdin` method that is a helper to choose the appopriate standard input. We also change the `Hoa\Console::advancedInteraction` behavior: 👷 `stty` uses the `-f` option to specify `/dev/tty` instead of the default standard input. However, on Linux, this is `-F`. I don't know how to address this right now (I mean: Making something cross-platform).

Finally, all `Hoa\Console`'s classes that were using `STDIN` directly are now using `Hoa\Console::getStdin`.

## New title

Actually, since #55, this PR has taken a new path. We also introduced an `Input` class. And it considers whether to use `Hoa\File\Read('php://stdin')` as the default input, or `Hoa\File\Read('/dev/tty')` in case the former has been closed. This is a basic wrapper.