### PR TITLE
Add TMUX(1) support for `Window::copy`

### DIFF
--- a/Console.php
+++ b/Console.php
@@ -311,6 +311,16 @@ class Console
 
         return static::$_tput;
     }
+
+    /**
+     * Check whether we are running behind TMUX(1).
+     *
+     * @return  bool
+     */
+    public static function isTmuxRunning()
+    {
+        return isset($_SERVER['TMUX']);
+    }
 }
 
 /**

--- a/Window.php
+++ b/Window.php
@@ -526,7 +526,15 @@ class Window implements Core\Event\Source
             return;
         }
 
-        echo "\033]52;;" . base64_encode($data) . "\033\\";
+        $out = "\033]52;;" . base64_encode($data) . "\033\\";
+
+        if (true === Console::isTmuxRunning()) {
+            echo "\033Ptmux;" . str_replace("\033", "\033\033", $out) . "\033\\";
+
+            return;
+        }
+
+        echo $out;
 
         return;
     }


### PR DESCRIPTION
Fix #52.

Two steps (one more is required to get something clean, in another issue):
1. Add the `Console::isTmuxRunning` method,
2. Add TMUX(1) support on `Window::copy`.

To check whether TMUX(1) is running, we use the following Shell command (see [Parameter expansion](http://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion)):
```sh
echo ${TMUX:-"no"}
```
I first used `${TMUX?}` but it prints an error on stderr if the variable is not defined. This “trick” is still clean though.

To add TMUX(1) support on `Window::copy`, we use information on this URL: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324. We learn there is a special form to by-pass TMUX(1) and send control sequences to the upper terminal. We have to use the:

    \033Ptmux;…\033\\

control sequence where `…` is the original control sequence where `\033` are doubled.

This PR is ready to be reviewed.

The next step is to have a unified way to write on the output (so far we only do `echo` and it sucks sometimes, e.g. with `Window::copy`; it is only more difficult to embed, /cc @jubianchi). I am opening a new issue right now.

I am assigning @jubianchi for the review.