### PR TITLE
Improve Output behavior.

### DIFF
--- a/Console.php
+++ b/Console.php
@@ -129,7 +129,7 @@ class Console
     /**
      * Output.
      *
-     * @var \Hoa\Stream\IStream\Out
+     * @var \Hoa\Console\Output
      */
     protected static $_output = null;
 
@@ -309,10 +309,10 @@ class Console
     /**
      * Set output layer.
      *
-     * @param   \Hoa\Stream\IStream\Out  $output    Output.
-     * @return  \Hoa\Stream\IStream\Out
+     * @param   \Hoa\Console\Output  $output    Output.
+     * @return  \Hoa\Console\Output
      */
-    public static function setOutput(Stream\IStream\Out $output)
+    public static function setOutput(Output $output)
     {
         $old             = static::$_output;
         static::$_output = $output;
@@ -323,7 +323,7 @@ class Console
     /**
      * Get output layer.
      *
-     * @return  \Hoa\Stream\IStream\Out
+     * @return  \Hoa\Console\Output
      */
     public static function getOutput()
     {

--- a/GetOption.php
+++ b/GetOption.php
@@ -128,8 +128,8 @@ class GetOption
     /**
      * Prepare the pipette.
      *
-     * @param   array                         $options    The option definition.
-     * @param   \Hoa\Console\Core\Cli\Parser  $parser     The parser.
+     * @param   array                $options    The option definition.
+     * @param   \Hoa\Console\Parser  $parser     The parser.
      * @return  void
      * @throws  \Hoa\Console\Exception
      */

--- a/Window.php
+++ b/Window.php
@@ -566,7 +566,7 @@ if (function_exists('pcntl_signal')) {
                 'hoa://Event/Console/Window:resize',
                 $_window,
                 new Core\Event\Bucket([
-                    'size' => \Window::getSize()
+                    'size' => Window::getSize()
                 ])
             );
         }

--- a/Window.php
+++ b/Window.php
@@ -532,20 +532,12 @@ class Window implements Core\Event\Source
             return;
         }
 
-        $out = "\033]52;;" . base64_encode($data) . "\033\\";
-
-        $output = Console::getOutput();
-
-        if ($output instanceof Output) {
-            $considerMultiplexer = $output->isMultiplexerConsidered();
-            $output->considerMultiplexer(true);
-        }
+        $out                 = "\033]52;;" . base64_encode($data) . "\033\\";
+        $output              = Console::getOutput();
+        $considerMultiplexer = $output->considerMultiplexer(true);
 
         $output->writeAll($out);
-
-        if ($output instanceof Output) {
-            $output->considerMultiplexer($considerMultiplexer);
-        }
+        $output->considerMultiplexer($considerMultiplexer);
 
         return;
     }


### PR DESCRIPTION
See https://github.com/hoaproject/Console/pull/55#discussion_r42047716

`Hoa\Console::getOutput` return `Hoa\Stream\IStream\Out` and then type
check must be done to allow correct uses of `Hoa\Console\Output`'s
multiplexer feature. Requiring type check in methods usage looks like
a wrong approach.
`Hoa\Console\Output` can embed an instance of `Hoa\Stream\IStream\Out`.
Like that `Output::isMultiplexerConsidered` &
`Output::considerMultiplexer` are always available. And when
`Output::write` is called, an internal call to `Hoa\Stream\IStream\Out`
is done.