### PR TITLE
If no terminfo found, fallback to `xterm`

### DIFF
--- a/Tput.php
+++ b/Tput.php
@@ -837,6 +837,10 @@ class Tput
             }
         }
 
+        if (null === $pathname && 'xterm' !== $term) {
+            return static::getTerminfo('xterm');
+        }
+
         return $pathname;
     }
 }

--- a/Tput.php
+++ b/Tput.php
@@ -784,7 +784,7 @@ class Tput
     public static function getTerm()
     {
         return
-            isset($_SERVER['TERM'])
+            isset($_SERVER['TERM']) && !empty($_SERVER['TERM'])
                 ? $_SERVER['TERM']
                 : (OS_WIN ? 'windows-ansi' : 'xterm');
     }


### PR DESCRIPTION
Should fix an issue with Cygwin. Will give details later.