### PR TITLE
Autocompleter: Force to work on a sub-line

### DIFF
--- a/Readline/Autocompleter/Word.php
+++ b/Readline/Autocompleter/Word.php
@@ -104,7 +104,7 @@ class Word implements Autocompleter
      */
     public function getWordDefinition()
     {
-        return '\b\w+\b';
+        return '\b\w+';
     }
 
     /**

--- a/Readline/Readline.php
+++ b/Readline/Readline.php
@@ -901,31 +901,23 @@ class Readline
         }
 
         $matches = preg_match_all(
-            '#' . $autocompleter->getWordDefinition() . '#u',
-            $line,
-            $words,
-            PREG_OFFSET_CAPTURE
+            '#' . $autocompleter->getWordDefinition() . '$#u',
+            mb_substr($line, 0, $current),
+            $words
         );
 
         if (0 === $matches) {
             return $state;
         }
 
-        for (
-            $i = 0, $max = count($words[0]);
-            $i < $max && $current > $words[0][$i][1];
-            ++$i
-        );
+        $word = $words[0][0];
 
-        $word = $words[0][$i - 1];
-
-        if ('' === trim($word[0])) {
+        if ('' === trim($word)) {
             return $state;
         }
 
-        $prefix   = mb_substr($word[0], 0, $current - $word[1]);
-        $solution = $autocompleter->complete($prefix);
-        $length   = mb_strlen($prefix);
+        $solution = $autocompleter->complete($word);
+        $length   = mb_strlen($word);
 
         if (null === $solution) {
             return $state;

--- a/Test/Unit/Readline/Autocompleter/Word.php
+++ b/Test/Unit/Readline/Autocompleter/Word.php
@@ -128,7 +128,7 @@ class Word extends Test\Unit\Suite
             ->when($result = $autocompleter->getWordDefinition())
             ->then
                 ->string($result)
-                    ->isEqualTo('\b\w+\b');
+                    ->isEqualTo('\b\w+');
     }
 
     public function case_set_words()


### PR DESCRIPTION
Fix #67.

Before this patch, all autocompleters were finding words on a complete
line. This were leading to some issues, like the one described in
https://github.com/hoaproject/Console/issues/67: If one has the “foo ”
line and starts autocompleting with the `Word` autocompleter, it will
find the `foo` word. Since the autocompletion algorithm chose the word
to autocomplete based on the closest offset, in this case it would have
tried to autocomplete `foo`, which is wrong because there is a space
after `foo` (“foo ”).

Now, instead of working with word offsets, the algorithm uses an anchor
(`$`) to find the latest word in the “line”. In fact, the algorithm no
longer works on the full line but on a subset of the line (called
“sub-line”), which starts from the beginning and ends at the current
position of the cursor.

In addition to fix the bug, it saves useless computations and regular
expressions matching. Also the algorithm is a little more simple to
understand. The notion of prefix has been removed too: The found word is
directly the prefix used by autocompleters.

Finally, no modification is needed on existing autocompleters regarding
the word definition. In this case, we were able to simplify the word
definition of `Word` but it is not related. There should be no backward
compatibility break.